### PR TITLE
stop panicing if ping thread fails

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -6,6 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use log::trace;
 use packet::icmp::Kind;
 use parking_lot::Mutex;
 use rand::random;
@@ -143,10 +144,10 @@ impl Pinger {
         let ident = self.ident;
         let cache = self.cache.clone();
         task::spawn(async move {
-            let _size = sender
-                .send_to(&mut packet, &sock_addr.into())
-                .await
-                .ok();
+            if let Err(e) = sender.send_to(&mut packet, &sock_addr.into()).await {
+                trace!("socket send packet error: {}", e)
+            }
+
             cache.insert(ident, seq_cnt, Instant::now());
         });
 

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -146,7 +146,7 @@ impl Pinger {
             let _size = sender
                 .send_to(&mut packet, &sock_addr.into())
                 .await
-                .expect("socket send packet error");
+                .ok();
             cache.insert(ident, seq_cnt, Instant::now());
         });
 


### PR DESCRIPTION
With this, the tokio worker threads won't panic anymore if anything went wrong.

This is useful if a crate like [human-panic](https://crates.io/crates/human-panic) is used, because otherwise users get full crash message for every single ping that couldn't be sent.