### PR TITLE
Support IPv6 EchoRequest/EchoReply

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 log = "0.4.14"
-packet = "0.1.4"
 parking_lot = "0.11.1"
+pnet_packet = "0.27.2"
 rand = "0.8.3"
-socket2 = { version = "0.4.0", features = ["all"]}
+socket2 = { version = "0.4.0", features = ["all"] }
 thiserror = "1.0.24"
 tokio = { version = "1.4", features = ["time", "macros"] }
 

--- a/examples/cmd.rs
+++ b/examples/cmd.rs
@@ -156,7 +156,10 @@ async fn main() {
                     reply.size,
                     reply.source,
                     reply.sequence,
-                    reply.ttl,
+                    match reply.ttl {
+                        Some(ttl) => format!("{}", ttl),
+                        None => "?".to_string(),
+                    },
                     dur.as_secs_f64() * 1000f64
                 );
                 answer.update(Some(dur));

--- a/examples/multi_ping.rs
+++ b/examples/multi_ping.rs
@@ -33,7 +33,14 @@ async fn ping(addr: IpAddr, size: usize) -> Result<(), Box<dyn std::error::Error
         match pinger.ping(idx).await {
             Ok((reply, dur)) => println!(
                 "{} bytes from {}: icmp_seq={} ttl={} time={:?}",
-                reply.size, reply.source, reply.sequence, reply.ttl, dur
+                reply.size,
+                reply.source,
+                reply.sequence,
+                match reply.ttl {
+                    Some(ttl) => format!("{}", ttl),
+                    None => "?".to_string(),
+                },
+                dur
             ),
             Err(e) => println!("{} ping {}", addr, e),
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use std::io;
 
-use packet::icmp::Kind;
+use pnet_packet::{icmp::IcmpType, icmpv6::Icmpv6Type};
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, SurgeError>;
@@ -10,14 +10,30 @@ pub type Result<T> = std::result::Result<T, SurgeError>;
 ///
 #[derive(Error, Debug)]
 pub enum SurgeError {
-    #[error("packet parse error")]
-    PacketError(#[from] packet::Error),
+    #[error("buffer size was too small")]
+    IncorrectBufferSize,
+    #[error("malformed packet: {0}")]
+    MalformedPacket(#[from] MalformedPacketError),
     #[error("io error")]
     IOError(#[from] io::Error),
-    #[error("packet kind error")]
-    KindError(Kind),
+    #[error("expected echoreply, got {0:?}")]
+    NotEchoReply(IcmpType),
+    #[error("expected echoreply, got {0:?}")]
+    NotV6EchoReply(Icmpv6Type),
     #[error("timeout error")]
     Timeout,
     #[error("other icmp message")]
     OtherICMP,
+}
+
+#[derive(Error, Debug)]
+pub enum MalformedPacketError {
+    #[error("expected an Ipv4Packet")]
+    NotIpv4Packet,
+    #[error("expected an IcmpPacket payload")]
+    NotIcmpPacket,
+    #[error("expected an Icmpv6Packet")]
+    NotIcmpv6Packet,
+    #[error("payload too short, got {got}, want {want}")]
+    PayloadTooShort { got: usize, want: usize },
 }

--- a/src/icmp.rs
+++ b/src/icmp.rs
@@ -1,22 +1,30 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::{convert::TryInto, net::IpAddr};
 
 use log::trace;
-use packet::builder::Builder;
-use packet::Packet;
-use packet::{icmp, ip};
+use pnet_packet::{
+    icmp::{
+        self, echo_reply::EchoReplyPacket, echo_request::MutableEchoRequestPacket, IcmpPacket,
+        IcmpTypes,
+    },
+    icmpv6::{Icmpv6Packet, Icmpv6Types, MutableIcmpv6Packet},
+    ipv4::Ipv4Packet,
+    Packet, PacketSize,
+};
 
-use crate::error::{Result, SurgeError};
+use crate::error::{MalformedPacketError, Result, SurgeError};
 
 #[derive(Debug)]
 pub struct EchoRequest {
+    pub destination: IpAddr,
     pub ident: u16,
     pub seq_cnt: u16,
     pub size: usize,
 }
 
 impl EchoRequest {
-    pub fn new(ident: u16, seq_cnt: u16, size: usize) -> Self {
+    pub fn new(destination: IpAddr, ident: u16, seq_cnt: u16, size: usize) -> Self {
         EchoRequest {
+            destination,
             ident,
             seq_cnt,
             size,
@@ -24,61 +32,143 @@ impl EchoRequest {
     }
 
     pub fn encode(&self) -> Result<Vec<u8>> {
-        let payload = vec![0; self.size];
-        let echo_request = icmp::Builder::default()
-            .echo()?
-            .request()?
-            .identifier(self.ident)?
-            .sequence(self.seq_cnt)?
-            .payload(&payload)?
-            .build()?;
-        Ok(echo_request)
+        match self.destination {
+            IpAddr::V4(_) => self.encode_icmp_v4(),
+            IpAddr::V6(_) => self.encode_icmp_v6(),
+        }
+    }
+
+    /// Encodes as an ICMPv4 EchoRequest.
+    fn encode_icmp_v4(&self) -> Result<Vec<u8>> {
+        let mut buf = vec![0; 8 + self.size]; // 8 bytes of header, then payload
+        let mut packet =
+            MutableEchoRequestPacket::new(&mut buf[..]).ok_or(SurgeError::IncorrectBufferSize)?;
+        packet.set_icmp_type(IcmpTypes::EchoRequest);
+        packet.set_identifier(self.ident);
+        packet.set_sequence_number(self.seq_cnt);
+
+        // Calculate and set the checksum
+        let icmp_packet =
+            IcmpPacket::new(packet.packet()).ok_or(SurgeError::IncorrectBufferSize)?;
+        let checksum = icmp::checksum(&icmp_packet);
+        packet.set_checksum(checksum);
+
+        Ok(packet.packet().to_vec())
+    }
+
+    /// Encodes as an ICMPv6 EchoRequest.
+    fn encode_icmp_v6(&self) -> Result<Vec<u8>> {
+        let mut buf = vec![0u8; 4 + 2 + 2 + self.size]; // 4 bytes ICMP header + 2 bytes ident + 2 bytes sequence, then payload
+        let mut packet =
+            MutableIcmpv6Packet::new(&mut buf[..]).ok_or(SurgeError::IncorrectBufferSize)?;
+        packet.set_icmpv6_type(Icmpv6Types::EchoRequest);
+
+        // Encode the identifier and sequence directly in the payload
+        let mut payload = vec![0; 4];
+        payload[0..2].copy_from_slice(&self.ident.to_be_bytes()[..]);
+        payload[2..4].copy_from_slice(&self.seq_cnt.to_be_bytes()[..]);
+        packet.set_payload(&payload);
+
+        // Per https://tools.ietf.org/html/rfc3542#section-3.1 the checksum is
+        // omitted, the kernel will insert it.
+
+        Ok(packet.packet().to_vec())
     }
 }
 
 /// `EchoReply` struct, which contains some packet information.
 #[derive(Debug)]
 pub struct EchoReply {
-    /// IP Time To Live for outgoing packets.
-    pub ttl: u8,
-    /// Source address of ICMP package.
-    pub source: Ipv4Addr,
-    /// Sequence of ICMP package.
+    /// IP Time To Live for outgoing packets. Present for ICMPv4 replies,
+    /// absent for ICMPv6 replies.
+    pub ttl: Option<u8>,
+    /// Source address of ICMP packet.
+    pub source: IpAddr,
+    /// Sequence of ICMP packet.
     pub sequence: u16,
-    /// Identifier of ICMP package.
+    /// Identifier of ICMP packet.
     pub identifier: u16,
-    /// Size of ICMP package.
+    /// Size of ICMP packet.
     pub size: usize,
 }
 
 impl EchoReply {
     /// Unpack IP packets received from socket as `EchoReply` struct.
     pub fn decode(addr: IpAddr, buf: &[u8]) -> Result<EchoReply> {
-        // dont use `ip::v4::Packet::new(buf)?`.
-        // Because `buf.as_ref().len() < packet.length() as usize` is always true.
-        let ip_packet = ip::v4::Packet::no_payload(buf)?;
-        if ip_packet.source() != addr {
-            return Err(SurgeError::OtherICMP);
-        }
-        let packet = icmp::Packet::new(ip_packet.payload())?;
-        if packet.kind() == icmp::Kind::EchoReply {
-            let echo_reply = packet.echo()?;
-            Ok(EchoReply {
-                ttl: ip_packet.ttl(),
-                source: ip_packet.source(),
-                sequence: echo_reply.sequence(),
-                identifier: echo_reply.identifier(),
-                size: echo_reply.payload().as_ref().len(),
-            })
-        } else {
-            trace!(
-                "type={:?},code={},src={},dst={}",
-                packet.kind(),
-                packet.code(),
-                ip_packet.source(),
-                ip_packet.destination()
-            );
-            Err(SurgeError::KindError(packet.kind()))
+        match addr {
+            IpAddr::V4(_) => decode_icmpv4(addr, &buf),
+            IpAddr::V6(_) => decode_icmpv6(addr, &buf),
         }
     }
+}
+
+/// Decodes an ICMPv4 packet received from an IPv4 raw socket
+fn decode_icmpv4(addr: IpAddr, buf: &[u8]) -> Result<EchoReply> {
+    let ipv4 = Ipv4Packet::new(buf)
+        .ok_or_else(|| SurgeError::from(MalformedPacketError::NotIpv4Packet))?;
+    let payload = ipv4.payload();
+    let icmp_packet = IcmpPacket::new(payload)
+        .ok_or_else(|| SurgeError::from(MalformedPacketError::NotIcmpPacket))?;
+    let ty = icmp_packet.get_icmp_type();
+    if ty != IcmpTypes::EchoReply {
+        trace!(
+            "type={:?},code={:?},src={},dst={}",
+            ty,
+            icmp_packet.get_icmp_code(),
+            ipv4.get_source(),
+            ipv4.get_destination()
+        );
+        return Err(SurgeError::NotEchoReply(ty));
+    }
+
+    let echo_reply_packet = EchoReplyPacket::new(payload).unwrap();
+    Ok(EchoReply {
+        ttl: Some(ipv4.get_ttl()),
+        source: addr,
+        sequence: echo_reply_packet.get_sequence_number(),
+        identifier: echo_reply_packet.get_identifier(),
+        size: echo_reply_packet.packet_size(),
+    })
+}
+
+/// Decodes an ICMPv6 packet received from an IPv6 raw socket
+fn decode_icmpv6(addr: IpAddr, buf: &[u8]) -> Result<EchoReply> {
+    // Per https://tools.ietf.org/html/rfc3542#section-3, ICMPv6 raw sockets
+    // *do not* provide access to the complete packet, only the payload,
+    // so there is no need to extract the payload as there is for ICMPv4
+    // packets.
+    let icmp_packet = Icmpv6Packet::new(buf)
+        .ok_or_else(|| SurgeError::from(MalformedPacketError::NotIcmpv6Packet))?;
+    let ty = icmp_packet.get_icmpv6_type();
+    if ty != Icmpv6Types::EchoReply {
+        trace!(
+            "type={:?},code={:?},src={}",
+            ty,
+            icmp_packet.get_icmpv6_code(),
+            addr
+        );
+        return Err(SurgeError::NotV6EchoReply(ty));
+    }
+
+    // pnet_packet doesn't provide a struct for Icmpv6EchoReply, extract
+    // the identifier and sequence directly. Payload must be at least 4 bytes
+    // for this to work.
+    let payload = icmp_packet.payload();
+    if payload.len() < 4 {
+        return Err(MalformedPacketError::PayloadTooShort {
+            got: payload.len(),
+            want: 4,
+        }
+        .into());
+    }
+    let identifier = u16::from_be_bytes(payload[0..2].try_into().unwrap());
+    let sequence = u16::from_be_bytes(payload[2..4].try_into().unwrap());
+
+    Ok(EchoReply {
+        ttl: None,
+        source: addr,
+        sequence,
+        identifier,
+        size: payload.len() - 4, // Subtract 4 bytes for ident and sequence
+    })
 }

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -6,7 +6,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use packet::icmp::Kind;
 use parking_lot::Mutex;
 use rand::random;
 use tokio::task;
@@ -73,7 +72,7 @@ impl Pinger {
             ident: random(),
             size: 56,
             timeout: Duration::from_secs(2),
-            socket: AsyncSocket::new()?,
+            socket: AsyncSocket::new(host)?,
             cache: Cache::new(),
         })
     }
@@ -105,7 +104,7 @@ impl Pinger {
         self
     }
 
-    /// The timeout of each Ping, in seconds.(default: 2s)
+    /// The timeout of each Ping, in seconds. (default: 2s)
     pub fn timeout(&mut self, timeout: Duration) -> &mut Pinger {
         self.timeout = timeout;
         self
@@ -126,7 +125,8 @@ impl Pinger {
                     }
                     continue;
                 }
-                Err(SurgeError::KindError(Kind::EchoRequest)) => continue,
+                Err(SurgeError::NotEchoReply(_)) => continue,
+                Err(SurgeError::NotV6EchoReply(_)) => continue,
                 Err(SurgeError::OtherICMP) => continue,
                 Err(e) => {
                     return Err(e);
@@ -138,7 +138,7 @@ impl Pinger {
     /// Send Ping request with sequence number.
     pub async fn ping(&self, seq_cnt: u16) -> Result<(EchoReply, Duration)> {
         let sender = self.socket.clone();
-        let mut packet = EchoRequest::new(self.ident, seq_cnt, self.size).encode()?;
+        let mut packet = EchoRequest::new(self.host, self.ident, seq_cnt, self.size).encode()?;
         let sock_addr = SocketAddr::new(self.host, 0);
         let ident = self.ident;
         let cache = self.cache.clone();


### PR DESCRIPTION
- Switch from `packet` to `pnet_packet`, which supports IPv6

- Implement encode/decode for IPv4/IPv6 echo requests and replies

- Use the destination IP address to open an IPv4 or IPv6 socket as
  appropriate.

Backwards compatibility:

- EchoReply.ttl is now an Option<u8>, as it's not accessible on ICMPv6
  replies in this implementation.