### PR TITLE
fix pnet_packet calulate icmp packet size wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for seq_cnt in 0..10 {
         let (reply, dur) = pinger.ping(seq_cnt).await?;
         println!(
-            "{} bytes from {}: icmp_seq={} ttl={} time={:?}",
+            "{} bytes from {}: icmp_seq={} ttl={:?} time={:?}",
             reply.size, reply.source, reply.sequence, reply.ttl, dur
         );
     }
@@ -41,16 +41,16 @@ $ cd surge-ping
 
 $ cargo build --example simple
 sudo RUST_LOG=info ./target/debug/examples/simple -h www.baidu.com -s 56
-INFO  simple > Ok((EchoReply { ttl: 48, source: 220.181.38.148, sequence: 0, size: 56 }, 7.4106ms))
+INFO  simple > Ok((EchoReply { ttl: Some(48), source: 220.181.38.148, sequence: 0, identifier: 111, size: 64 }, 7.4106ms))
 
 $ cargo build --example cmd
 sudo ./target/debug/examples/cmd -h www.baidu.com -c 5
 PING www.baidu.com (220.181.38.149): 56 data bytes
-56 bytes from 220.181.38.149: icmp_seq=0 ttl=45 time=8.987 ms
-56 bytes from 220.181.38.149: icmp_seq=1 ttl=45 time=15.662 ms
-56 bytes from 220.181.38.149: icmp_seq=2 ttl=45 time=14.924 ms
-56 bytes from 220.181.38.149: icmp_seq=3 ttl=45 time=8.902 ms
-56 bytes from 220.181.38.149: icmp_seq=4 ttl=45 time=11.281 ms
+64 bytes from 220.181.38.149: icmp_seq=0 ttl=45 time=8.987 ms
+64 bytes from 220.181.38.149: icmp_seq=1 ttl=45 time=15.662 ms
+64 bytes from 220.181.38.149: icmp_seq=2 ttl=45 time=14.924 ms
+64 bytes from 220.181.38.149: icmp_seq=3 ttl=45 time=8.902 ms
+64 bytes from 220.181.38.149: icmp_seq=4 ttl=45 time=11.281 ms
 
 --- www.baidu.com ping statistics ---
 5 packets transmitted, 5 packets received, 0.00% packet loss

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -50,7 +50,10 @@ async fn main() {
         .unwrap();
 
     let mut pinger = Pinger::new(ip).unwrap();
-    pinger.ident(111).size(56).timeout(Duration::from_secs(1));
+    pinger
+        .ident(111)
+        .size(opt.size)
+        .timeout(Duration::from_secs(1));
     let answer = pinger.ping(0).await;
     info!("{:?}", answer);
 }

--- a/src/icmp.rs
+++ b/src/icmp.rs
@@ -8,7 +8,7 @@ use pnet_packet::{
     },
     icmpv6::{Icmpv6Packet, Icmpv6Types, MutableIcmpv6Packet},
     ipv4::Ipv4Packet,
-    Packet, PacketSize,
+    Packet,
 };
 
 use crate::error::{MalformedPacketError, Result, SurgeError};
@@ -127,7 +127,8 @@ fn decode_icmpv4(addr: IpAddr, buf: &[u8]) -> Result<EchoReply> {
         source: addr,
         sequence: echo_reply_packet.get_sequence_number(),
         identifier: echo_reply_packet.get_identifier(),
-        size: echo_reply_packet.packet_size(),
+        // TODO: When `EchoReplyPacket::packet_size()` can directly use.
+        size: echo_reply_packet.packet().len(),
     })
 }
 


### PR DESCRIPTION
https://docs.rs/pnet_packet/0.27.2/pnet_packet/icmp/echo_reply/struct.EchoReplyPacket.html#method.packet_size

There is a problem with this function design, you need to create an `EchoReply` instance before you can get the right `packet_size`.