### PR TITLE
Fix memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,36 +12,31 @@ rust ping libray based on `tokio` + `socket2` + `pnet_packet`.
 
 ## Example
 
-```rust
-use std::time::Duration;
+simple usage:
 
+```rust
 use surge_ping::IcmpPacket;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut pinger = surge_ping::pinger("114.114.114.114".parse()?).await?;
-    // let client = Client::new(&Config::default())?;
-    // let mut pinger = client.pinger("114.114.114.114".parse()?);
-    pinger.timeout(Duration::from_secs(1));
-    for seq_cnt in 0..10 {
-        match pinger.ping(seq_cnt).await? {
-            (IcmpPacket::V4(packet), dur) => {
-                println!(
-                    "{} bytes from {}: icmp_seq={} ttl={:?} time={:?}",
-                    packet.get_size(),
-                    packet.get_source(),
-                    packet.get_sequence(),
-                    packet.get_ttl(),
-                    dur
-                );
-            }
-            (IcmpPacket::V6(_), dur) => unreachable!(),
+async fn main() {
+    match surge_ping::ping("127.0.0.1".parse().unwrap()).await {
+        Ok((IcmpPacket::V4(packet), duration)) => {
+            println!(
+                "{} bytes from {}: icmp_seq={} ttl={:?} time={:.2?}",
+                packet.get_size(),
+                packet.get_source(),
+                packet.get_sequence(),
+                packet.get_ttl(),
+                duration
+            );
         }
-    }
-    Ok(())
+        Ok(_) => unreachable!(),
+        Err(e) => println!("{:?}", e),
+    };
 }
-
 ```
+
+multi address usage: [multi_ping.rs](https://github.com/kolapapa/surge-ping/blob/main/examples/multi_ping.rs)
 
 ### Ping(ICMP)
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -94,10 +94,8 @@ pub struct Client {
 
 impl Drop for Client {
     fn drop(&mut self) {
-        println!("client is drop");
         if self.shutdown_tx.send(()).is_err() {
             warn!("Client shutdown error.");
-            println!("client shutdown error");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ impl Default for ICMP {
 ///
 /// - socket create failed
 ///
-pub async fn ping(host: IpAddr) -> error::Result<(IcmpPacket, Duration)> {
+pub async fn ping(host: IpAddr) -> Result<(IcmpPacket, Duration), SurgeError> {
     let config = match host {
         IpAddr::V4(_) => Config::default(),
         IpAddr::V6(_) => Config::builder().kind(ICMP::V6).build(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 mod icmp;
 mod ping;
 
-use std::net::IpAddr;
+use std::{net::IpAddr, time::Duration};
 
 pub use client::Client;
 pub use config::{Config, ConfigBuilder};
@@ -24,7 +24,7 @@ impl Default for ICMP {
     }
 }
 
-/// Shortcut method to quickly make a `Pinger`.
+/// Shortcut method to ping address.
 /// **NOTE**: This function creates a new internal `Client` on each call,
 /// and so should not be used if making many target. Create a
 /// [`Client`](./struct.Client.html) instead.
@@ -32,7 +32,10 @@ impl Default for ICMP {
 /// # Examples
 ///
 /// ```rust
-/// let mut pinger = surge_ping::pinger("8.8.8.8".parse()?).await?;
+/// match surge_ping::ping("127.0.0.1".parse()?).await {
+///     Ok((_packet, duration)) => println!("duration: {:.2?}", duration),
+///     Err(e) => println!("{:?}", e),
+/// };
 /// ```
 ///
 /// # Errors
@@ -41,12 +44,12 @@ impl Default for ICMP {
 ///
 /// - socket create failed
 ///
-pub async fn pinger(host: IpAddr) -> Result<Pinger, SurgeError> {
+pub async fn ping(host: IpAddr) -> error::Result<(IcmpPacket, Duration)> {
     let config = match host {
         IpAddr::V4(_) => Config::default(),
         IpAddr::V6(_) => Config::builder().kind(ICMP::V6).build(),
     };
     let client = Client::new(&config).await?;
-    let pinger = client.pinger(host).await;
-    Ok(pinger)
+    let mut pinger = client.pinger(host).await;
+    pinger.ping(0).await
 }


### PR DESCRIPTION
- Remove `surge_ping::pinger(host: IpAddr)` to created `Pinger`, replace with `surge_ping::ping(host: IpAddr)` to quick send ping request;
- `Client` impl `Drop` trait, if the `Client` out of lifetime, then stop the background task;
- `Pinger` impl `Drop` trait, if `Pinger` out of lifetime, then remove key from cache;
- Modify `README.md`;

