### PR TITLE
Error on send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ socket2 = { version = "0.4.4", features = ["all"] }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["time", "macros"] }
 tracing = "0.1.32"
-uuid = { version = "0.8.2", features = ["v4"] }
+uuid = { version = "1.0.0", features = ["v4"] }
 
 [dev-dependencies]
 structopt = "0.3.26"

--- a/examples/cmd.rs
+++ b/examples/cmd.rs
@@ -147,7 +147,7 @@ async fn main() {
     }
     let config = config_builder.build();
 
-    let client = Client::new(&config).await.unwrap();
+    let client = Client::new(&config).unwrap();
     let mut pinger = client.pinger(ip).await;
     pinger.timeout(Duration::from_secs(opt.timeout));
 

--- a/examples/multi_ping.rs
+++ b/examples/multi_ping.rs
@@ -17,8 +17,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "2a02:930::ff76",
         "114.114.114.114",
     ];
-    let client_v4 = Client::new(&Config::default()).await?;
-    let client_v6 = Client::new(&Config::builder().kind(ICMP::V6).build()).await?;
+    let client_v4 = Client::new(&Config::default())?;
+    let client_v6 = Client::new(&Config::builder().kind(ICMP::V6).build())?;
     let mut tasks = Vec::new();
     for ip in &ips {
         match ip.parse() {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -44,7 +44,7 @@ async fn main() {
     }
     let config = config_builder.build();
 
-    let client = Client::new(&config).await.unwrap();
+    let client = Client::new(&config).unwrap();
     let mut pinger = client.pinger(ip).await;
     pinger
         .ident(111)

--- a/src/client.rs
+++ b/src/client.rs
@@ -103,7 +103,7 @@ impl Drop for Client {
 impl Client {
     /// A client is generated according to the configuration. In fact, a `AsyncSocket` is wrapped inside,
     /// and you can clone to any `task` at will.
-    pub async fn new(config: &Config) -> io::Result<Self> {
+    pub fn new(config: &Config) -> io::Result<Self> {
         let socket = AsyncSocket::new(config)?;
         let mapping = Arc::new(Mutex::new(HashMap::new()));
         let (shutdown_tx, _) = broadcast::channel(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub async fn ping(host: IpAddr) -> Result<(IcmpPacket, Duration), SurgeError> {
         IpAddr::V4(_) => Config::default(),
         IpAddr::V6(_) => Config::builder().kind(ICMP::V6).build(),
     };
-    let client = Client::new(&config).await?;
+    let client = Client::new(&config)?;
     let mut pinger = client.pinger(host).await;
     pinger.ping(0).await
 }


### PR DESCRIPTION
Hi!

This PR changes the behavior of `ping()` to return an error when send fails. This since it seems appropriate to let the caller know what went wrong instead of just getting a timeout.
Might have missed some detail but couldn't see any reason for why the send call was done in a separate task so I removed that spawn call too.

Also removed async from the Client::new() since it doesn't do any async work.
And bumped uuid to v1.

Hope it's to any use! And thanks for sharing this library :crab: 
