### PR TITLE
Identify reply by host, indentifier and sequence number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 parking_lot = "0.12.0"
-pnet_packet = "0.29.0"
+pnet_packet = "0.30"
 rand = "0.8.5"
 socket2 = { version = "0.4.4", features = ["all"] }
 thiserror = "1.0.30"
-tokio = { version = "1.17.0", features = ["time", "macros"] }
+tokio = { version = "1.17", features = ["time", "sync"] }
 tracing = "0.1.34"
 
 

--- a/examples/cmd.rs
+++ b/examples/cmd.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use structopt::StructOpt;
-use surge_ping::{Client, Config, IcmpPacket, ICMP};
+use surge_ping::{Client, Config, IcmpPacket, PingSequence, ICMP};
 use tokio::time;
 
 #[derive(Default, Debug)]
@@ -155,7 +155,7 @@ async fn main() {
     println!("PING {} ({}): {} data bytes", opt.host, ip, opt.size);
     for idx in 0..opt.count {
         interval.tick().await;
-        match pinger.ping(idx).await {
+        match pinger.ping(PingSequence(idx)).await {
             Ok((IcmpPacket::V4(reply), dur)) => {
                 println!(
                     "{} bytes from {}: icmp_seq={} ttl={} time={:0.3?}",

--- a/examples/multi_ping.rs
+++ b/examples/multi_ping.rs
@@ -2,7 +2,7 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use futures::future::join_all;
-use surge_ping::{Client, Config, IcmpPacket, ICMP};
+use surge_ping::{Client, Config, IcmpPacket, PingSequence, ICMP};
 use tokio::time;
 
 #[tokio::main]
@@ -42,7 +42,7 @@ async fn ping(client: Client, addr: IpAddr) {
     let mut interval = time::interval(Duration::from_secs(1));
     for idx in 0..5 {
         interval.tick().await;
-        match pinger.ping(idx).await {
+        match pinger.ping(PingSequence(idx)).await {
             Ok((IcmpPacket::V4(packet), dur)) => println!(
                 "No.{}: {} bytes from {}: icmp_seq={} ttl={} time={:0.2?}",
                 idx,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use structopt::StructOpt;
-use surge_ping::{Client, Config, ICMP};
+use surge_ping::{Client, Config, PingIdentifier, PingSequence, ICMP};
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "surge-ping")]
@@ -47,10 +47,10 @@ async fn main() {
     let client = Client::new(&config).unwrap();
     let mut pinger = client.pinger(ip).await;
     pinger
-        .ident(111)
+        .ident(PingIdentifier(111))
         .size(opt.size)
         .timeout(Duration::from_secs(1));
-    match pinger.ping(0).await {
+    match pinger.ping(PingSequence(0)).await {
         Ok((packet, rtt)) => {
             println!("{:?} {:0.2?}", packet, rtt);
         }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -44,13 +44,11 @@ async fn main() {
     }
     let config = config_builder.build();
 
+    let payload = vec![0; opt.size];
     let client = Client::new(&config).unwrap();
-    let mut pinger = client.pinger(ip).await;
-    pinger
-        .ident(PingIdentifier(111))
-        .size(opt.size)
-        .timeout(Duration::from_secs(1));
-    match pinger.ping(PingSequence(0)).await {
+    let mut pinger = client.pinger(ip, PingIdentifier(111)).await;
+    pinger.timeout(Duration::from_secs(1));
+    match pinger.ping(PingSequence(0), &payload).await {
         Ok((packet, rtt)) => {
             println!("{:?} {:0.2?}", packet, rtt);
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
-use std::io;
+use std::{io, net::IpAddr};
 
 use thiserror::Error;
 
-use crate::icmp::PingSequence;
+use crate::{icmp::PingSequence, PingIdentifier};
 
 pub type Result<T> = std::result::Result<T, SurgeError>;
 
@@ -23,6 +23,12 @@ pub enum SurgeError {
     EchoRequestPacket,
     #[error("Network error.")]
     NetworkError,
+    #[error("Multiple identical request")]
+    IdenticalRequests {
+        host: IpAddr,
+        ident: PingIdentifier,
+        seq: PingSequence,
+    },
 }
 
 #[derive(Error, Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@ use std::io;
 
 use thiserror::Error;
 
+use crate::icmp::PingSequence;
+
 pub type Result<T> = std::result::Result<T, SurgeError>;
 
 /// An error resulting from a ping option-setting or send/receive operation.
@@ -16,7 +18,7 @@ pub enum SurgeError {
     #[error("io error")]
     IOError(#[from] io::Error),
     #[error("Request timeout for icmp_seq {seq}")]
-    Timeout { seq: u16 },
+    Timeout { seq: PingSequence },
     #[error("Echo Request packet.")]
     EchoRequestPacket,
     #[error("Network error.")]

--- a/src/icmp/icmpv4.rs
+++ b/src/icmp/icmpv4.rs
@@ -12,16 +12,15 @@ use super::{PingIdentifier, PingSequence};
 pub fn make_icmpv4_echo_packet(
     ident: PingIdentifier,
     seq_cnt: PingSequence,
-    size: usize,
-    key: &[u8],
+    payload: &[u8],
 ) -> Result<Vec<u8>> {
-    let mut buf = vec![0; 8 + size]; // 8 bytes of header, then payload
+    let mut buf = vec![0; 8 + payload.len()]; // 8 bytes of header, then payload
     let mut packet = icmp::echo_request::MutableEchoRequestPacket::new(&mut buf[..])
         .ok_or(SurgeError::IncorrectBufferSize)?;
     packet.set_icmp_type(icmp::IcmpTypes::EchoRequest);
     packet.set_identifier(ident.into_u16());
     packet.set_sequence_number(seq_cnt.into_u16());
-    packet.set_payload(key);
+    packet.set_payload(payload);
 
     // Calculate and set the checksum
     let icmp_packet =

--- a/src/icmp/icmpv6.rs
+++ b/src/icmp/icmpv6.rs
@@ -13,16 +13,15 @@ use super::{PingIdentifier, PingSequence};
 pub fn make_icmpv6_echo_packet(
     ident: PingIdentifier,
     seq_cnt: PingSequence,
-    size: usize,
-    key: &[u8],
+    payload: &[u8],
 ) -> Result<Vec<u8>> {
-    let mut buf = vec![0; 8 + size]; // 8 bytes of header, then payload
+    let mut buf = vec![0; 8 + payload.len()]; // 8 bytes of header, then payload
     let mut packet = icmpv6::echo_request::MutableEchoRequestPacket::new(&mut buf[..])
         .ok_or(SurgeError::IncorrectBufferSize)?;
     packet.set_icmpv6_type(icmpv6::Icmpv6Types::EchoRequest);
     packet.set_identifier(ident.into_u16());
     packet.set_sequence_number(seq_cnt.into_u16());
-    packet.set_payload(key);
+    packet.set_payload(payload);
 
     // Per https://tools.ietf.org/html/rfc3542#section-3.1 the checksum is
     // omitted, the kernel will insert it.

--- a/src/icmp/mod.rs
+++ b/src/icmp/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt, net::IpAddr};
+use std::fmt;
 
 pub mod icmpv4;
 pub mod icmpv6;
@@ -13,22 +13,17 @@ pub enum IcmpPacket {
 }
 
 impl IcmpPacket {
-    /// Check reply Icmp packet is corret.
-    pub fn check_reply_packet(
-        &self,
-        destination: IpAddr,
-        seq_cnt: PingSequence,
-        identifier: PingIdentifier,
-    ) -> bool {
+    pub fn get_identifier(&self) -> PingIdentifier {
         match self {
-            IcmpPacket::V4(packet) => {
-                destination.eq(&IpAddr::V4(packet.get_real_dest()))
-                    && packet.get_sequence() == seq_cnt
-                    && packet.get_identifier() == identifier
-            }
-            IcmpPacket::V6(packet) => {
-                packet.get_sequence() == seq_cnt && packet.get_identifier() == identifier
-            }
+            IcmpPacket::V4(packet) => packet.get_identifier(),
+            IcmpPacket::V6(packet) => packet.get_identifier(),
+        }
+    }
+
+    pub fn get_sequence(&self) -> PingSequence {
+        match self {
+            IcmpPacket::V4(packet) => packet.get_sequence(),
+            IcmpPacket::V6(packet) => packet.get_sequence(),
         }
     }
 }

--- a/src/icmp/mod.rs
+++ b/src/icmp/mod.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::{fmt, net::IpAddr};
 
 pub mod icmpv4;
 pub mod icmpv6;
@@ -14,7 +14,12 @@ pub enum IcmpPacket {
 
 impl IcmpPacket {
     /// Check reply Icmp packet is corret.
-    pub fn check_reply_packet(&self, destination: IpAddr, seq_cnt: u16, identifier: u16) -> bool {
+    pub fn check_reply_packet(
+        &self,
+        destination: IpAddr,
+        seq_cnt: PingSequence,
+        identifier: PingIdentifier,
+    ) -> bool {
         match self {
             IcmpPacket::V4(packet) => {
                 destination.eq(&IpAddr::V4(packet.get_real_dest()))
@@ -25,5 +30,47 @@ impl IcmpPacket {
                 packet.get_sequence() == seq_cnt && packet.get_identifier() == identifier
             }
         }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct PingIdentifier(pub u16);
+
+impl PingIdentifier {
+    pub fn into_u16(self) -> u16 {
+        self.0
+    }
+}
+
+impl fmt::Display for PingIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<u16> for PingIdentifier {
+    fn from(ident: u16) -> Self {
+        Self(ident)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct PingSequence(pub u16);
+
+impl PingSequence {
+    pub fn into_u16(self) -> u16 {
+        self.0
+    }
+}
+
+impl fmt::Display for PingSequence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<u16> for PingSequence {
+    fn from(seq_cnt: u16) -> Self {
+        Self(seq_cnt)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,9 @@ use std::{net::IpAddr, time::Duration};
 pub use client::Client;
 pub use config::{Config, ConfigBuilder};
 pub use error::SurgeError;
-pub use icmp::{icmpv4::Icmpv4Packet, icmpv6::Icmpv6Packet, IcmpPacket};
+pub use icmp::{
+    icmpv4::Icmpv4Packet, icmpv6::Icmpv6Packet, IcmpPacket, PingIdentifier, PingSequence,
+};
 pub use ping::Pinger;
 
 #[derive(Debug, Clone, Copy)]
@@ -51,5 +53,5 @@ pub async fn ping(host: IpAddr) -> Result<(IcmpPacket, Duration), SurgeError> {
     };
     let client = Client::new(&config)?;
     let mut pinger = client.pinger(host).await;
-    pinger.ping(0).await
+    pinger.ping(PingSequence(0)).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use icmp::{
     icmpv4::Icmpv4Packet, icmpv6::Icmpv6Packet, IcmpPacket, PingIdentifier, PingSequence,
 };
 pub use ping::Pinger;
+use rand::random;
 
 #[derive(Debug, Clone, Copy)]
 pub enum ICMP {
@@ -34,7 +35,7 @@ impl Default for ICMP {
 /// # Examples
 ///
 /// ```rust
-/// match surge_ping::ping("127.0.0.1".parse()?).await {
+/// match surge_ping::ping("127.0.0.1".parse()?, &[1,2,3,4,5,6,7,8]).await {
 ///     Ok((_packet, duration)) => println!("duration: {:.2?}", duration),
 ///     Err(e) => println!("{:?}", e),
 /// };
@@ -46,12 +47,12 @@ impl Default for ICMP {
 ///
 /// - socket create failed
 ///
-pub async fn ping(host: IpAddr) -> Result<(IcmpPacket, Duration), SurgeError> {
+pub async fn ping(host: IpAddr, payload: &[u8]) -> Result<(IcmpPacket, Duration), SurgeError> {
     let config = match host {
         IpAddr::V4(_) => Config::default(),
         IpAddr::V6(_) => Config::builder().kind(ICMP::V6).build(),
     };
     let client = Client::new(&config)?;
-    let mut pinger = client.pinger(host).await;
-    pinger.ping(PingSequence(0)).await
+    let mut pinger = client.pinger(host, PingIdentifier(random())).await;
+    pinger.ping(PingSequence(0), payload).await
 }

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,69 +1,32 @@
 use std::{
-    collections::HashMap,
     net::{IpAddr, SocketAddr},
-    sync::Arc,
     time::{Duration, Instant},
 };
 
-use parking_lot::Mutex;
-use rand::random;
-use tokio::{
-    sync::{broadcast, mpsc},
-    task,
-    time::timeout,
-};
-use tracing::warn;
+use tokio::time::timeout;
 
-use crate::icmp::{icmpv4, icmpv6, IcmpPacket};
 use crate::{
-    client::{AsyncSocket, ClientMapping, Message, UniqueId},
-    icmp::PingSequence,
-};
-use crate::{
+    client::{AsyncSocket, ReplyMap},
     error::{Result, SurgeError},
-    icmp::PingIdentifier,
+    icmp::{icmpv4, icmpv6, IcmpPacket, PingIdentifier, PingSequence},
 };
-
-type Token = (PingIdentifier, PingSequence);
-
-#[derive(Debug, Clone)]
-struct Cache {
-    inner: Arc<Mutex<HashMap<Token, Instant>>>,
-}
-
-impl Cache {
-    fn new() -> Cache {
-        Cache {
-            inner: Arc::new(Mutex::new(HashMap::new())),
-        }
-    }
-
-    fn insert(&self, ident: PingIdentifier, seq_cnt: PingSequence, time: Instant) {
-        self.inner.lock().insert((ident, seq_cnt), time);
-    }
-
-    fn remove(&self, ident: PingIdentifier, seq_cnt: PingSequence) -> Option<Instant> {
-        self.inner.lock().remove(&(ident, seq_cnt))
-    }
-}
 
 /// A Ping struct represents the state of one particular ping instance.
 pub struct Pinger {
-    pub destination: IpAddr,
+    pub host: IpAddr,
     pub ident: PingIdentifier,
-    pub size: usize,
     timeout: Duration,
     socket: AsyncSocket,
-    rx: mpsc::Receiver<Message>,
-    cache: Cache,
-    key: UniqueId,
-    clear_tx: broadcast::Sender<()>,
+    reply_map: ReplyMap,
+    last_sequence: Option<PingSequence>,
 }
 
 impl Drop for Pinger {
     fn drop(&mut self) {
-        if self.clear_tx.send(()).is_err() {
-            warn!("Clear Pinger cache failed");
+        if let Some(sequence) = self.last_sequence.take() {
+            // Ensure no reply waiter is left hanging if this pinger is dropped while
+            // waiting for a reply.
+            self.reply_map.remove(self.host, self.ident, sequence);
         }
     }
 }
@@ -71,36 +34,18 @@ impl Drop for Pinger {
 impl Pinger {
     pub(crate) fn new(
         host: IpAddr,
+        ident: PingIdentifier,
         socket: AsyncSocket,
-        rx: mpsc::Receiver<Message>,
-        key: UniqueId,
-        mapping: ClientMapping,
+        response_map: ReplyMap,
     ) -> Pinger {
-        let (clear_tx, _) = broadcast::channel(1);
-        task::spawn(clear_mapping_key(key, mapping, clear_tx.subscribe()));
         Pinger {
-            destination: host,
-            ident: PingIdentifier(random()),
-            size: 56,
+            host,
+            ident,
             timeout: Duration::from_secs(2),
             socket,
-            rx,
-            cache: Cache::new(),
-            key,
-            clear_tx,
+            reply_map: response_map,
+            last_sequence: None,
         }
-    }
-
-    /// Set the identification of ICMP.
-    pub fn ident(&mut self, val: PingIdentifier) -> &mut Pinger {
-        self.ident = val;
-        self
-    }
-
-    /// Set the packet payload size, minimal is 16. (default: 56)
-    pub fn size(&mut self, size: usize) -> &mut Pinger {
-        self.size = if size < 16 { 16 } else { size };
-        self
     }
 
     /// The timeout of each Ping, in seconds. (default: 2s)
@@ -109,62 +54,38 @@ impl Pinger {
         self
     }
 
-    async fn recv_reply(&mut self, seq_cnt: PingSequence) -> Result<(IcmpPacket, Duration)> {
-        loop {
-            let message = self.rx.recv().await.ok_or(SurgeError::NetworkError)?;
-            let packet = match self.destination {
-                IpAddr::V4(_) => icmpv4::Icmpv4Packet::decode(&message.packet).map(IcmpPacket::V4),
-                IpAddr::V6(a) => {
-                    icmpv6::Icmpv6Packet::decode(&message.packet, a).map(IcmpPacket::V6)
-                }
-            };
-            match packet {
-                Ok(packet) => {
-                    if packet.check_reply_packet(self.destination, seq_cnt, self.ident) {
-                        if let Some(ins) = self.cache.remove(self.ident, seq_cnt) {
-                            return Ok((packet, message.when - ins));
-                        }
-                    }
-                }
-                Err(SurgeError::EchoRequestPacket) => continue,
-                Err(e) => return Err(e),
-            }
-        }
-    }
-
     /// Send Ping request with sequence number.
-    pub async fn ping(&mut self, seq_cnt: PingSequence) -> Result<(IcmpPacket, Duration)> {
-        let sender = self.socket.clone();
-        let mut packet = match self.destination {
-            IpAddr::V4(_) => {
-                icmpv4::make_icmpv4_echo_packet(self.ident, seq_cnt, self.size, &self.key)?
-            }
-            IpAddr::V6(_) => {
-                icmpv6::make_icmpv6_echo_packet(self.ident, seq_cnt, self.size, &self.key)?
+    pub async fn ping(
+        &mut self,
+        seq: PingSequence,
+        payload: &[u8],
+    ) -> Result<(IcmpPacket, Duration)> {
+        // Register to wait for a reply.
+        let reply_waiter = self.reply_map.new_waiter(self.host, self.ident, seq)?;
+
+        // Create and send ping packet.
+        let mut packet = match self.host {
+            IpAddr::V4(_) => icmpv4::make_icmpv4_echo_packet(self.ident, seq, payload)?,
+            IpAddr::V6(_) => icmpv6::make_icmpv6_echo_packet(self.ident, seq, payload)?,
+        };
+        self.socket
+            .send_to(&mut packet, &SocketAddr::new(self.host, 0))
+            .await?;
+        let send_time = Instant::now();
+        self.last_sequence = Some(seq);
+
+        // Wait for reply or timeout.
+        let result = match timeout(self.timeout, reply_waiter).await {
+            Ok(Ok(reply)) => Ok((
+                reply.packet,
+                reply.timestamp.saturating_duration_since(send_time),
+            )),
+            Ok(Err(_err)) => Err(SurgeError::NetworkError),
+            Err(_) => {
+                self.reply_map.remove(self.host, self.ident, seq);
+                Err(SurgeError::Timeout { seq })
             }
         };
-        // let mut packet = EchoRequest::new(self.host, self.ident, seq_cnt, self.size).encode()?;
-        let sock_addr = SocketAddr::new(self.destination, 0);
-        let ident = self.ident;
-
-        sender.send_to(&mut packet, &sock_addr).await?;
-        self.cache.insert(ident, seq_cnt, Instant::now());
-
-        match timeout(self.timeout, self.recv_reply(seq_cnt)).await {
-            Ok(reply) => reply.map_err(|err| {
-                self.cache.remove(ident, seq_cnt);
-                err
-            }),
-            Err(_) => {
-                self.cache.remove(ident, seq_cnt);
-                Err(SurgeError::Timeout { seq: seq_cnt })
-            }
-        }
-    }
-}
-
-async fn clear_mapping_key(key: UniqueId, mapping: ClientMapping, mut rx: broadcast::Receiver<()>) {
-    if rx.recv().await.is_ok() {
-        mapping.lock().await.remove(&key);
+        result
     }
 }


### PR DESCRIPTION
Hi @kolapapa,

I wanted to modify the library to allow it to send a payload smaller than 16 bytes. To achieve this I replaced the lookup of replies using the uuid/random identifier carried in payload by using the pinged host+ping identifier+sequence number. So for each sent request we expect a reply with the same parameters. This change also means that two pingers pinging the same host with the same ident and same sequence number at the same time can not be allowed. Trying to do this now will result in an error.

However my initial, seemingly small change ended up being quite big. And I realize this might not suite this library and your case so I very much understand if you won't accept this PR. Still wanted to give you a chance to have a look and see if it can be to any use.

Thanks again for sharing this library!