### PR TITLE
Check bounds before accessing array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["tokio", "icmp", "ping"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
+hex = "0.4.3"
 parking_lot = "0.12.0"
 pnet_packet = "0.30"
 rand = "0.8.5"

--- a/src/icmp/icmpv6.rs
+++ b/src/icmp/icmpv6.rs
@@ -160,8 +160,16 @@ impl Icmpv6Packet {
         match icmpv6_packet.get_icmpv6_type() {
             icmpv6::Icmpv6Types::EchoRequest => Err(SurgeError::EchoRequestPacket),
             icmpv6::Icmpv6Types::EchoReply => {
-                let identifier = u16::from_be_bytes(icmpv6_payload[0..2].try_into().unwrap());
-                let sequence = u16::from_be_bytes(icmpv6_payload[2..4].try_into().unwrap());
+                let identifier_payload = icmpv6_payload
+                    .get(0..2)
+                    .ok_or(MalformedPacketError::NotIcmpv6Packet)?;
+                let identifier = u16::from_be_bytes(identifier_payload.try_into().unwrap());
+
+                let sequence_payload = icmpv6_payload
+                    .get(2..4)
+                    .ok_or(MalformedPacketError::NotIcmpv6Packet)?;
+                let sequence = u16::from_be_bytes(sequence_payload.try_into().unwrap());
+
                 let mut packet = Icmpv6Packet::default();
                 packet
                     .source(destination)
@@ -177,8 +185,16 @@ impl Icmpv6Packet {
             }
             _ => {
                 // ipv6 header(40) + icmpv6 echo header(4)
-                let identifier = u16::from_be_bytes(icmpv6_payload[44..46].try_into().unwrap());
-                let sequence = u16::from_be_bytes(icmpv6_payload[46..48].try_into().unwrap());
+                let identifier_payload = icmpv6_payload
+                    .get(44..46)
+                    .ok_or(MalformedPacketError::NotIcmpv6Packet)?;
+                let identifier = u16::from_be_bytes(identifier_payload.try_into().unwrap());
+
+                let sequence_payload = icmpv6_payload
+                    .get(46..48)
+                    .ok_or(MalformedPacketError::NotIcmpv6Packet)?;
+                let sequence = u16::from_be_bytes(sequence_payload.try_into().unwrap());
+
                 let mut packet = Icmpv6Packet::default();
                 packet
                     .source(destination)


### PR DESCRIPTION
We saw some crashes on an older version of this library. I went through and attempted to add bounds checking before raw array access to ensure we don't crash and instead return an error.