### PR TITLE
Fix tokio features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ pnet_packet = "0.31"
 rand = "0.8.5"
 socket2 = { version = "0.4.7", features = ["all"] }
 thiserror = "1.0.37"
-tokio = { version = "1.21", features = ["time", "sync"] }
+tokio = { version = "1.21", features = ["time", "sync", "net", "rt"] }
 tracing = "0.1.37"
 
 


### PR DESCRIPTION
Without these features, there are unresolved imports that cause the crate to not compile. The suggested fix seems to be for the user to depend on tokio with the correct features, but it isn't documented anywhere explicitly that I could find and it seems wrong to have the user fix something that should be handled by the library.