### PR TITLE
Multiplatform changes

### DIFF
--- a/examples/cmd.rs
+++ b/examples/cmd.rs
@@ -158,7 +158,7 @@ async fn main() {
         match pinger.ping(PingSequence(idx), &payload).await {
             Ok((IcmpPacket::V4(reply), dur)) => {
                 println!(
-                    "{} bytes from {}: icmp_seq={} ttl={} time={:0.3?}",
+                    "{} bytes from {}: icmp_seq={} ttl={:?} time={:0.3?}",
                     reply.get_size(),
                     reply.get_source(),
                     reply.get_sequence(),

--- a/examples/multi_ping.rs
+++ b/examples/multi_ping.rs
@@ -46,7 +46,7 @@ async fn ping(client: Client, addr: IpAddr) {
         interval.tick().await;
         match pinger.ping(PingSequence(idx), &payload).await {
             Ok((IcmpPacket::V4(packet), dur)) => println!(
-                "No.{}: {} bytes from {}: icmp_seq={} ttl={} time={:0.2?}",
+                "No.{}: {} bytes from {}: icmp_seq={} ttl={:?} time={:0.2?}",
                 idx,
                 packet.get_size(),
                 packet.get_source(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,18 +1,32 @@
 use std::net::SocketAddr;
 
-use socket2::SockAddr;
+use socket2::{SockAddr, Type};
 
 use crate::ICMP;
 
 /// Config is the packaging of various configurations of `sockets`. If you want to make
 /// some `set_socket_opt` and other modifications, please define and implement them in `Config`.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Config {
+    pub sock_type_hint: Type,
     pub kind: ICMP,
     pub bind: Option<SockAddr>,
     pub interface: Option<String>,
     pub ttl: Option<u32>,
     pub fib: Option<u32>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            sock_type_hint: Type::DGRAM,
+            kind: ICMP::default(),
+            bind: None,
+            interface: None,
+            ttl: None,
+            fib: None,
+        }
+    }
 }
 
 impl Config {
@@ -26,13 +40,27 @@ impl Config {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ConfigBuilder {
+    sock_type_hint: Type,
     kind: ICMP,
     bind: Option<SockAddr>,
     interface: Option<String>,
     ttl: Option<u32>,
     fib: Option<u32>,
+}
+
+impl Default for ConfigBuilder {
+    fn default() -> Self {
+        Self {
+            sock_type_hint: Type::DGRAM,
+            kind: ICMP::default(),
+            bind: None,
+            interface: None,
+            ttl: None,
+            fib: None,
+        }
+    }
 }
 
 impl ConfigBuilder {
@@ -75,8 +103,15 @@ impl ConfigBuilder {
         self
     }
 
+    /// Try to open the socket with provided at first (DGRAM or RAW)
+    pub fn sock_type_hint(mut self, typ: Type) -> Self {
+        self.sock_type_hint = typ;
+        self
+    }
+
     pub fn build(self) -> Config {
         Config {
+            sock_type_hint: self.sock_type_hint,
             kind: self.kind,
             bind: self.bind,
             interface: self.interface,

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,7 @@ pub enum SurgeError {
     #[error("Multiple identical request")]
     IdenticalRequests {
         host: IpAddr,
-        ident: PingIdentifier,
+        ident: Option<PingIdentifier>,
         seq: PingSequence,
     },
 }

--- a/src/icmp/icmpv4.rs
+++ b/src/icmp/icmpv4.rs
@@ -288,24 +288,71 @@ impl Icmpv4Packet {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::Icmpv4Packet;
 
     #[test]
     fn malformed_packet() {
-        let decoded = hex::decode("4500001d0000000079018a76acd90e6e0a00f22203006c3293cc").unwrap();
-        assert!(Icmpv4Packet::decode(&decoded).is_err());
+        let decoded_ipv4 =
+            hex::decode("4500001d0000000079018a76acd90e6e0a00f22203006c3293cc").unwrap();
+        assert!(Icmpv4Packet::decode(
+            &decoded_ipv4,
+            SockType::RAW,
+            ("172.217.14.110").parse().unwrap(),
+            ("10.0.242.34").parse().unwrap(),
+        )
+        .is_err());
+
+        let decoded_icmp = hex::decode("03006c3293cc").unwrap();
+        assert!(Icmpv4Packet::decode(
+            &decoded_icmp,
+            SockType::DGRAM,
+            ("172.217.14.110").parse().unwrap(),
+            ("10.0.242.34").parse().unwrap(),
+        )
+        .is_err());
     }
 
     #[test]
     fn short_packet() {
-        let decoded =
+        let decoded_ipv4 =
             hex::decode("4500001d0000000079018a76acd90e6e0a00f22203006c3293cc000100").unwrap();
-        assert!(Icmpv4Packet::decode(&decoded).is_err());
+        assert!(Icmpv4Packet::decode(
+            &decoded_ipv4,
+            SockType::RAW,
+            ("172.217.14.110").parse().unwrap(),
+            ("10.0.242.34").parse().unwrap(),
+        )
+        .is_err());
+
+        let decoded_icmp = hex::decode("03006c3293cc000100").unwrap();
+        assert!(Icmpv4Packet::decode(
+            &decoded_icmp,
+            SockType::DGRAM,
+            ("172.217.14.110").parse().unwrap(),
+            ("10.0.242.34").parse().unwrap(),
+        )
+        .is_err());
     }
 
     #[test]
     fn standard_packet() {
-        let decoded = hex::decode("45000054000000007901067e8efab00e0a00f22203004176a1ee0001613dd762000000002127040000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637").unwrap();
-        Icmpv4Packet::decode(&decoded).unwrap();
+        let decoded_ipv4 = hex::decode("45000054000000007901067e8efab00e0a00f22203004176a1ee0001613dd762000000002127040000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637").unwrap();
+        Icmpv4Packet::decode(
+            &decoded_ipv4,
+            SockType::RAW,
+            ("172.217.14.110").parse().unwrap(),
+            ("10.0.242.34").parse().unwrap(),
+        )
+        .unwrap();
+
+        let decoded_icmp = hex::decode("03004176a1ee0001613dd762000000002127040000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637").unwrap();
+        Icmpv4Packet::decode(
+            &decoded_icmp,
+            SockType::DGRAM,
+            ("172.217.14.110").parse().unwrap(),
+            ("10.0.242.34").parse().unwrap(),
+        )
+        .unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod ping;
 
 use std::{net::IpAddr, time::Duration};
 
-pub use client::Client;
+pub use client::{AsyncSocket, Client};
 pub use config::{Config, ConfigBuilder};
 pub use error::SurgeError;
 pub use icmp::{

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -39,12 +39,11 @@ impl Pinger {
         socket: AsyncSocket,
         response_map: ReplyMap,
     ) -> Pinger {
-        let ident;
-        if is_linux_icmp_socket!(socket.get_type()) {
-            ident = None;
+        let ident = if is_linux_icmp_socket!(socket.get_type()) {
+            None
         } else {
-            ident = Some(ident_hint);
-        }
+            Some(ident_hint)
+        };
 
         Pinger {
             host,
@@ -78,7 +77,7 @@ impl Pinger {
         self.last_sequence = Some(seq);
 
         // Wait for reply or timeout.
-        let result = match timeout(self.timeout, reply_waiter).await {
+        match timeout(self.timeout, reply_waiter).await {
             Ok(Ok(reply)) => Ok((
                 reply.packet,
                 reply.timestamp.saturating_duration_since(send_time),
@@ -88,12 +87,11 @@ impl Pinger {
                 self.reply_map.remove(self.host, self.ident, seq);
                 Err(SurgeError::Timeout { seq })
             }
-        };
-        result
+        }
     }
 
     /// Send a ping packet (useful, when you don't need a reply).
-    pub async fn send_ping(&mut self, seq: PingSequence, payload: &[u8]) -> Result<()> {
+    pub async fn send_ping(&self, seq: PingSequence, payload: &[u8]) -> Result<()> {
         // Create and send ping packet.
         let mut packet = match self.host {
             IpAddr::V4(_) => icmpv4::make_icmpv4_echo_packet(


### PR DESCRIPTION
So I've made some changes, for this crate to work on not only one platform (my guess it was `macOS`,  that it was tested with previously), but on `linux` and `windows` as well.

- On windows, there isn't such thing as `DGRAM + ICMP` socket, so we have to use RAW socket.
- On `linux`, `DGRAM + ICMP` works (if there are sufficient group permissions for user to open this socket), but socket itself operates on ICMP protocol level (you do not have access to IP packet). You can fetch additional IP header info (like `ttl`) with `recvmsg` syscall, but this API is not available on `tokio::net::UdpSocket`.
- On linux, you cannot set `PingIdentifier` field manually, when on DGRAM + ICMP socket. This is set by kernel to _internal_  socket's port value.

There are some additional changes, which I personally found useful (e.g. `send_ping()` without waiting for reply, exposing native socket, to add some `socketopts` ...) and added them to API.

