### PR TITLE
Add interface index, update socket2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hex = "0.4.3"
 parking_lot = "0.12.1"
 pnet_packet = "0.34"
 rand = "0.9.0"
-socket2 = { version = "0.5.6", features = ["all"] }
+socket2 = { version = "0.6.1", features = ["all"] }
 thiserror = "1.0.57"
 tokio = { version = "1.36", features = ["time", "sync", "net", "rt"] }
 tracing = "0.1.40"

--- a/src/client.rs
+++ b/src/client.rs
@@ -59,6 +59,25 @@ impl AsyncSocket {
         if let Some(interface) = &config.interface {
             socket.bind_device(Some(interface.as_bytes()))?;
         }
+        #[cfg(any(
+            target_os = "ios",
+            target_os = "visionos",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "illumos",
+            target_os = "solaris",
+            target_os = "linux",
+            target_os = "android",
+        ))]
+        {
+            if config.interface_index.is_some() {
+                match config.kind {
+                    ICMP::V4 => socket.bind_device_by_index_v4(config.interface_index)?,
+                    ICMP::V6 => socket.bind_device_by_index_v6(config.interface_index)?,
+                }
+            }
+        }
         if let Some(ttl) = config.ttl {
             match config.kind {
                 ICMP::V4 => socket.set_ttl_v4(ttl)?,

--- a/src/client.rs
+++ b/src/client.rs
@@ -60,7 +60,10 @@ impl AsyncSocket {
             socket.bind_device(Some(interface.as_bytes()))?;
         }
         if let Some(ttl) = config.ttl {
-            socket.set_ttl(ttl)?;
+            match config.kind {
+                ICMP::V4 => socket.set_ttl_v4(ttl)?,
+                ICMP::V6 => socket.set_unicast_hops_v6(ttl)?,
+            }
         }
         #[cfg(target_os = "freebsd")]
         if let Some(fib) = config.fib {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, num::NonZeroU32};
 
 use socket2::{SockAddr, Type};
 
@@ -12,6 +12,7 @@ pub struct Config {
     pub kind: ICMP,
     pub bind: Option<SockAddr>,
     pub interface: Option<String>,
+    pub interface_index: Option<NonZeroU32>,
     pub ttl: Option<u32>,
     pub fib: Option<u32>,
 }
@@ -23,6 +24,7 @@ impl Default for Config {
             kind: ICMP::default(),
             bind: None,
             interface: None,
+            interface_index: None,
             ttl: None,
             fib: None,
         }
@@ -46,6 +48,7 @@ pub struct ConfigBuilder {
     kind: ICMP,
     bind: Option<SockAddr>,
     interface: Option<String>,
+    interface_index: Option<NonZeroU32>,
     ttl: Option<u32>,
     fib: Option<u32>,
 }
@@ -57,6 +60,7 @@ impl Default for ConfigBuilder {
             kind: ICMP::default(),
             bind: None,
             interface: None,
+            interface_index: None,
             ttl: None,
             fib: None,
         }
@@ -80,6 +84,12 @@ impl ConfigBuilder {
     /// works for some socket types, particularly `AF_INET` sockets.
     pub fn interface(mut self, interface: &str) -> Self {
         self.interface = Some(interface.to_string());
+        self
+    }
+
+    /// Sets the value for the `IP_BOUND_IF`, `IPV6_BOUND_IF` or `SO_BINDTOIFINDEX` option on this socket depending on the platform and IP address family.
+    pub fn interface_index(mut self, interface_index: NonZeroU32) -> Self {
+        self.interface_index = Some(interface_index);
         self
     }
 
@@ -115,6 +125,7 @@ impl ConfigBuilder {
             kind: self.kind,
             bind: self.bind,
             interface: self.interface,
+            interface_index: self.interface_index,
             ttl: self.ttl,
             fib: self.fib,
         }


### PR DESCRIPTION
This PR introduces the following changes:

- Update `socket2` to `0.6.1`. `ttl` is [properly assigned based on IP family](https://github.com/rust-lang/socket2/issues/418#issuecomment-1660056639), either using `set_ttl_v4()` or `set_unicast_hops_v6()`. Supersedes #43
- Add configuration option for binding to interface by index (`interface_index`). This is generally a suggested way on Apple platforms based on what I picked up from their documentation.