### PR TITLE
feat: update deps, edition and set MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming", "asynchronous"]
 hex = "0.4.3"
 parking_lot = "0.12.5"
 pnet_packet = "0.35"
-rand = "0.10.0"
+rand = "0.9.0"
 socket2 = { version = "0.6.2", features = ["all"] }
 thiserror = "2.0.18"
 tokio = { version = "1.49", features = ["time", "sync", "net", "rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hex = "0.4.3"
 parking_lot = "0.12.5"
 pnet_packet = "0.35"
 rand = "0.9.0"
-socket2 = { version = "0.6.2", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 thiserror = "2.0.18"
 tokio = { version = "1.49", features = ["time", "sync", "net", "rt"] }
 tracing = "0.1.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,20 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 hex = "0.4.3"
-parking_lot = "0.12.1"
-pnet_packet = "0.34"
-rand = "0.9.0"
-socket2 = { version = "0.6.1", features = ["all"] }
-thiserror = "1.0.57"
-tokio = { version = "1.36", features = ["time", "sync", "net", "rt"] }
-tracing = "0.1.40"
+parking_lot = "0.12.5"
+pnet_packet = "0.35"
+rand = "0.10.0"
+socket2 = { version = "0.6.2", features = ["all"] }
+thiserror = "2.0.18"
+tokio = { version = "1.49", features = ["time", "sync", "net", "rt"] }
+tracing = "0.1.44"
 
 
 [dev-dependencies]
 structopt = "0.3.26"
-pretty_env_logger = "0.4.0"
+pretty_env_logger = "0.5.0"
 tokio = { version = "1", features = ["full"] }
-futures = "0.3.25"
+futures = "0.3.32"
 
 [[example]]
 name = "simple"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "surge-ping"
 version = "0.8.4"
 authors = ["kolapapa <kolapapa2021@gmail.com>"]
-edition = "2018"
+edition = "2024"
+rust-version = "1.85.0"
 license = "MIT"
 homepage = "https://github.com/kolapapa/surge-ping"
 repository = "https://github.com/kolapapa/surge-ping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ rand = "0.10"
 socket2 = { version = "0.6", features = ["all"] }
 thiserror = "2.0"
 tokio = { version = "1.36", features = ["time", "sync", "net", "rt"] }
-tracing = "0.1.44"
-
+tracing = "0.1.40"
 
 [dev-dependencies]
 structopt = "0.3.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["network-programming", "asynchronous"]
 hex = "0.4.3"
 parking_lot = "0.12.5"
 pnet_packet = "0.35"
-rand = "0.9.0"
+rand = "0.10.0"
 socket2 = { version = "0.6", features = ["all"] }
 thiserror = "2.0.18"
-tokio = { version = "1.49", features = ["time", "sync", "net", "rt"] }
+tokio = { version = "1.50", features = ["time", "sync", "net", "rt"] }
 tracing = "0.1.44"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 hex = "0.4.3"
-parking_lot = "0.12.5"
+parking_lot = "0.12.1"
 pnet_packet = "0.35"
-rand = "0.10.0"
+rand = "0.10"
 socket2 = { version = "0.6", features = ["all"] }
-thiserror = "2.0.18"
-tokio = { version = "1.50", features = ["time", "sync", "net", "rt"] }
+thiserror = "2.0"
+tokio = { version = "1.36", features = ["time", "sync", "net", "rt"] }
 tracing = "0.1.44"
 
 
@@ -25,7 +25,7 @@ tracing = "0.1.44"
 structopt = "0.3.26"
 pretty_env_logger = "0.5.0"
 tokio = { version = "1", features = ["full"] }
-futures = "0.3.32"
+futures = "0.3.25"
 
 [[example]]
 name = "simple"


### PR DESCRIPTION
This PR updates the dependencies which have major (and/or minor) bumps, also sets MSRV to 1.85.0 due to `rand 0.10` and edition to `2024`, before this change, the real MSRV would have been `1.70` due to `socket 0.6`.

I'd also like to suggest removing `rand` completely as we use it just in the shortcut method:
https://github.com/kolapapa/surge-ping/blob/5b43f93756fca52fb9bf47bb757955ff5d7c42bf/src/lib.rs#L56
and add a parameter to it for the identifier. 
Or as an alternative we could feature gate it.

Note: Running tests locally, 2 of them fail but they also do that on main
